### PR TITLE
feat(babel): use jsdoc-to-assert

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -5,6 +5,7 @@
   "env": {
     "development": {
       "presets": [
+        "jsdoc-to-assert",
         "power-assert"
       ]
     }

--- a/package.json
+++ b/package.json
@@ -22,6 +22,9 @@
     "test": "test"
   },
   "scripts": {
+    "build": "NODE_END=production babel src --out-dir lib --source-maps",
+    "watch": "babel src --out-dir lib --watch --source-maps",
+    "prepublish": "npm run --if-present build",
     "test": "mocha"
   },
   "keywords": [
@@ -29,7 +32,11 @@
     "babel"
   ],
   "devDependencies": {
+    "babel-cli": "^6.7.5",
+    "babel-plugin-auto-import-assert": "^1.0.2",
+    "babel-plugin-jsdoc-to-assert": "^1.6.0",
     "babel-preset-es2015": "^6.6.0",
+    "babel-preset-jsdoc-to-assert": "^1.0.1",
     "babel-preset-power-assert": "^1.0.0",
     "babel-register": "^6.7.2",
     "mocha": "^2.4.5"

--- a/src/add.js
+++ b/src/add.js
@@ -1,7 +1,9 @@
 "use strict";
-const assert = require("assert");
+/**
+ * @param {number} x
+ * @param {number} y
+ * @returns {Number}
+ */
 export default function add(x, y) {
-    assert(typeof x === "number");
-    assert(typeof y === "number");
     return x + y;
 }

--- a/test/add-test.js
+++ b/test/add-test.js
@@ -11,7 +11,7 @@ describe("add", function () {
 
             throw new Error("unreachable line");
         } catch (error) {
-            assert(error instanceof assert.AssertionError);
+            assert.equal(error.name, assert.AssertionError.name);
         }
     });
 });


### PR DESCRIPTION
use [azu/babel-preset-jsdoc-to-assert: Babel plugin for jsdoc-to-assert](https://github.com/azu/babel-preset-jsdoc-to-assert)
